### PR TITLE
fix crash in tds when interlocking is unreachable

### DIFF
--- a/src/TrainDetectionSystem/TrainDetectionSystem.cs
+++ b/src/TrainDetectionSystem/TrainDetectionSystem.cs
@@ -241,9 +241,14 @@ namespace EulynxLive.TrainDetectionSystem
 
             if (_currentConnection != null)
             {
-                var occupancyStatus = new TrainDetectionSystemTvpsOccupancyStatusMessage(tps, _remoteId, _trackSectionStatuses[tps],
-                    TvpsAbilityToBeForcedToClear.NotAbleToBeForcedToClear, (ushort)0xfffe, TvpsPomStatus.NotApplicable);
-                await _currentConnection.RequestStream.WriteAsync(new SciPacket() { Message = ByteString.CopyFrom(occupancyStatus.ToByteArray()) });
+                try {
+                    var occupancyStatus = new TrainDetectionSystemTvpsOccupancyStatusMessage(tps, _remoteId, _trackSectionStatuses[tps],
+                        TvpsAbilityToBeForcedToClear.NotAbleToBeForcedToClear, (ushort)0xfffe, TvpsPomStatus.NotApplicable);
+                    await _currentConnection.RequestStream.WriteAsync(new SciPacket() { Message = ByteString.CopyFrom(occupancyStatus.ToByteArray()) });
+                } catch (ObjectDisposedException)
+                {
+                    _logger.LogWarning("Occupancy state could not be sent to the interlocking");
+                }
             }
 
             await UpdateConnectedWebClients();
@@ -270,9 +275,14 @@ namespace EulynxLive.TrainDetectionSystem
 
             if (_currentConnection != null)
             {
-                var occupancyStatus = new TrainDetectionSystemTvpsOccupancyStatusMessage(tps, _remoteId, _trackSectionStatuses[tps],
-                    TvpsAbilityToBeForcedToClear.NotAbleToBeForcedToClear, (ushort)0xfffe, TvpsPomStatus.NotApplicable);
-                await _currentConnection.RequestStream.WriteAsync(new SciPacket() { Message = ByteString.CopyFrom(occupancyStatus.ToByteArray()) });
+                try {
+                    var occupancyStatus = new TrainDetectionSystemTvpsOccupancyStatusMessage(tps, _remoteId, _trackSectionStatuses[tps],
+                        TvpsAbilityToBeForcedToClear.NotAbleToBeForcedToClear, (ushort)0xfffe, TvpsPomStatus.NotApplicable);
+                    await _currentConnection.RequestStream.WriteAsync(new SciPacket() { Message = ByteString.CopyFrom(occupancyStatus.ToByteArray()) });
+                } catch (ObjectDisposedException)
+                {
+                    _logger.LogWarning("Occupancy state could not be sent to the interlocking");
+                }
             }
 
             await UpdateConnectedWebClients();


### PR DESCRIPTION
When the connection from the TDS component to the interlocking is lost (or couldn't be established in the first place) and the TDS still receives a axle counting messsage, it tries to send the state to the interlocking and crashes. This PR wraps the state reporting in a try/catch to be able to keep tracking the state anyways.