### PR TITLE
Define and log the software version

### DIFF
--- a/src/Point/Point.cs
+++ b/src/Point/Point.cs
@@ -10,9 +10,11 @@ using Microsoft.AspNetCore.SignalR;
 using PropertyChanged.SourceGenerator;
 
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Net.WebSockets;
 using System.Reactive;
 using System.Reactive.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
 namespace EulynxLive.Point
@@ -267,6 +269,10 @@ namespace EulynxLive.Point
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
+            // Log version information
+            var version = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion;
+            _logger.LogInformation("Simulator software version: {}", version ?? "unknown");
+
             // Main loop.
             while (!stoppingToken.IsCancellationRequested)
             {

--- a/src/Point/Point.csproj
+++ b/src/Point/Point.csproj
@@ -9,6 +9,10 @@
     <IsPackable>false</IsPackable>
     <SpaRoot>rasta-point-web\</SpaRoot>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(SpaRoot)node_modules\**</DefaultItemExcludes>
+    <Version>1.1.0</Version>
+    <Company>Systems Lab 21 GmbH</Company>
+    <Product>EULYNX Point Simulator</Product>
+    <Description>Simulator for EULYNX SCI-P Electronic Field Element Subsystem</Description>
   </PropertyGroup>
 
   <ItemGroup>
@@ -77,6 +81,16 @@
   <!-- Provide the point.proto for download -->
   <Target Name="CopyCustomContentOnPublish" AfterTargets="PublishRunWebpack">
     <Copy SourceFiles="..\ProtobufInterfaces\proto\point.proto" DestinationFolder="$(PublishDir)$(SpaRoot)build" />
+  </Target>
+
+  <Target Name="SetSourceRevisionId" BeforeTargets="InitializeSourceControlInformation">
+    <Exec
+      Command="git describe --long --always --dirty --exclude=* --abbrev=8"
+      ConsoleToMSBuild="True"
+      IgnoreExitCode="False"
+      >
+      <Output PropertyName="SourceRevisionId" TaskParameter="ConsoleOutput"/>
+    </Exec>
   </Target>
 
 </Project>

--- a/src/Point/Startup.cs
+++ b/src/Point/Startup.cs
@@ -40,7 +40,7 @@ namespace EulynxLive.Point
             }
             catch (Exception e)
             {
-                Console.WriteLine($"Usage: --PointSettings:LocalId=<> --PointSettings:LocalRastaId=<> --PointSettings:RemoteId=<> --PointSettings:RemoteEndpoint=<>. {e.Message}");
+                Console.WriteLine($"One of the required configuration options was not provided. {e.Message}");
                 Environment.Exit(1);
             }
 


### PR DESCRIPTION
Combines the version string 1.1.0 with the current git commit hash.

Related reading:

 - https://stackoverflow.com/questions/15141338/embed-git-commit-hash-in-a-net-dll
 - https://learn.microsoft.com/de-de/dotnet/core/project-sdk/msbuild-props
 - https://stackoverflow.com/questions/7770068/get-the-net-assemblys-assemblyinformationalversion-value
 - https://stackoverflow.com/questions/42138418/equivalent-to-assemblyinfo-in-dotnet-core-csproj